### PR TITLE
Improve winner reveal UX

### DIFF
--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -57,6 +57,11 @@ export function renderTable(tableState, userId) {
       seatsMap[p.seat] = p;
   });
 
+  const revealAll = state.phase === 'result';
+  const winners = revealAll && state.winner
+    ? (Array.isArray(state.winner) ? state.winner.map(String) : [String(state.winner)])
+    : [];
+
   const angles = getSeatAngles(N_SEATS);
 
   // Определяем seat дилера (если есть)
@@ -94,6 +99,7 @@ export function renderTable(tableState, userId) {
       // Место занято — игрок
       if (String(player.user_id) === String(userId)) seatDiv.classList.add('my-seat');
       if (String(state.current_player) === String(player.user_id)) seatDiv.classList.add('active');
+      if (winners.includes(String(player.user_id))) seatDiv.classList.add('winner');
 
       // Карты игрока
       const cardsEl = document.createElement('div');
@@ -101,7 +107,7 @@ export function renderTable(tableState, userId) {
       (state.hole_cards?.[player.user_id] || []).forEach(c => {
         const cd = document.createElement('div');
         cd.className = 'card';
-        if (String(player.user_id) === String(userId)) {
+        if (revealAll || String(player.user_id) === String(userId)) {
           const rk = c.slice(0, -1);
           const st = c.slice(-1);
           cd.innerHTML = `<span class="rank">${rk}</span><span class="suit">${st}</span>`;

--- a/webapp/js/ui_game.js
+++ b/webapp/js/ui_game.js
@@ -59,6 +59,11 @@ Object.assign(resultOverlayEl.style, {
 });
 document.body.appendChild(resultOverlayEl);
 
+// Баннер победителя
+const winnerBannerEl = document.createElement('div');
+winnerBannerEl.id = 'winner-banner';
+document.body.appendChild(winnerBannerEl);
+
 // Добавляем CSS-класс для «затемнения» кнопок
 const style = document.createElement('style');
 style.textContent = `
@@ -149,49 +154,24 @@ function updateUI(state) {
 
   window.currentTableState = state;
 
-  // 1) Если стадия «result» – показываем оверлей и сбрасываем таймаут
+  // 1) Если стадия «result» – показываем баннер победителя и сбрасываем таймаут
   if (state.phase === 'result') {
     clearAutoAction();
-    resultOverlayEl.innerHTML = '';
-    const msg = document.createElement('div');
-    msg.style.marginBottom = '20px';
-
+    resultOverlayEl.style.display = 'none';
+    winnerBannerEl.classList.remove('visible');
     if (Array.isArray(state.winner)) {
-      msg.textContent = `Split pot: ${state.winner.map(u => state.usernames[u] || u).join(', ')}`;
+      winnerBannerEl.textContent = `Split pot: ${state.winner.map(u => state.usernames[u] || u).join(', ')}`;
     } else {
-      msg.textContent = `Winner: ${state.usernames[state.winner] || state.winner}`;
+      winnerBannerEl.textContent = `Winner: ${state.usernames[state.winner] || state.winner}`;
     }
-    resultOverlayEl.appendChild(msg);
-
-    const handsDiv = document.createElement('div');
-    for (const [uid, cards] of Object.entries(state.revealed_hands || {})) {
-      const p = document.createElement('div');
-      p.textContent = `${state.usernames[uid] || uid}: ${cards.join(' ')}`;
-      handsDiv.appendChild(p);
-    }
-    resultOverlayEl.appendChild(handsDiv);
-
-    if (state.split_pots) {
-      const splitDiv = document.createElement('div');
-      splitDiv.style.marginTop = '20px';
-      splitDiv.textContent = 'Payouts: ' +
-        Object.entries(state.split_pots)
-          .map(([uid, amt]) => `${state.usernames[uid] || uid}: ${amt}`)
-          .join(', ');
-      resultOverlayEl.appendChild(splitDiv);
-    }
-
-    resultOverlayEl.style.display    = 'flex';
-    pokerTableEl.style.display       = 'none';
-    actionsEl.style.display          = 'none';
-    statusEl.style.display           = 'none';
-    potEl.style.display              = 'none';
-    currentBetEl.style.display       = 'none';
+    winnerBannerEl.classList.add('visible');
+    actionsEl.style.display = 'none';
     return;
   }
 
-  // 2) Скрываем оверлей, показываем остальную UI
+  // 2) Скрываем баннер и показываем UI
   resultOverlayEl.style.display = 'none';
+  winnerBannerEl.classList.remove('visible');
   pokerTableEl.style.display    = '';
   statusEl.style.display        = '';
   potEl.style.display           = '';

--- a/webapp/table.css
+++ b/webapp/table.css
@@ -407,6 +407,30 @@ input[type=number] {
 .action-buttons-wrapper .call,
 .action-buttons-wrapper .check { border-color: #ccc; color: #fff; }
 
+/* Подсветка победителя */
+.seat.winner {
+  box-shadow: 0 0 18px #ffd700, 0 0 34px 8px #ffd70088;
+  border: 2.5px solid #ffd700;
+}
+
+#winner-banner {
+  position: absolute;
+  left: 50%;
+  top: 10%;
+  transform: translate(-50%, -50%);
+  background: rgba(255,215,0,0.95);
+  color: #000;
+  padding: 8px 18px;
+  border-radius: 12px;
+  font-weight: 800;
+  font-size: 1.2em;
+  opacity: 0;
+  transition: opacity 0.6s;
+  z-index: 2000;
+  pointer-events: none;
+}
+#winner-banner.visible { opacity: 1; }
+
 /* Адаптивность! */
 @media (max-width: 700px) {
   #poker-table, #poker-table-border, #seats {


### PR DESCRIPTION
## Summary
- highlight winner seats
- display hole cards for all players at showdown
- show a smooth winner banner instead of dark overlay

## Testing
- `python -m py_compile game_engine.py game_data.py db_utils.py game_ws.py server.py crypto_poker_bot.py tables.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ffc4c0cc832cbcc0a818bf01d9ee