### PR TITLE
Fix seating broadcast

### DIFF
--- a/game_ws.py
+++ b/game_ws.py
@@ -38,6 +38,15 @@ def on_sit(data):
     else:
         emit('waitingForOpponent', {'msg': 'Ожидание второго игрока...'}, room=sid)
 
+    seats_state = []
+    for i in range(MAX_PLAYERS):
+        player = room.players.get(i)
+        seats_state.append({
+            'empty': not bool(player),
+            'name': player.get('sid') if player else None
+        })
+    emit('tableState', {'seats': seats_state}, room=room_id)
+
 async def broadcast(table_id: int):
     state = game_states.get(table_id)
     if not state:

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -1,6 +1,7 @@
 import { listTables, joinTable } from './api.js';
 
 const socket = io();
+const CURRENT_ROOM_ID = 'room1';
 
 const infoContainer = document.getElementById('info');
 const levelSelect   = document.getElementById('level-select');
@@ -118,6 +119,10 @@ document.getElementById('confirmSit')?.addEventListener('click', () => {
   const modal = document.getElementById('depositModal');
   const seatIndex = +modal.dataset.seat;
   const deposit = parseFloat(document.getElementById('depositInput').value);
-  socket.emit('sitAtTable', { seatIndex, deposit });
+  socket.emit('sitAtTable', {
+    roomId: CURRENT_ROOM_ID,
+    seatIndex,
+    deposit
+  });
   modal.style.display = 'none';
 });


### PR DESCRIPTION
## Summary
- send room id when seating from lobby
- broadcast table state to room after player sits

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a320de618832ca8118da368eace81