### PR TITLE
Implement seat selection with deposit

### DIFF
--- a/game_engine.py
+++ b/game_engine.py
@@ -8,6 +8,22 @@ from db_utils import get_balance_db, set_balance_db
 game_states: Dict[int, dict] = {}
 connections: Dict[int, List] = {}
 
+# ---------- Helpers ----------
+def create_new_state(max_players: int) -> dict:
+    """Создаёт и возвращает пустое состояние стола."""
+    return {
+        "seats": [None] * max_players,
+        "player_seats": {},
+        "players": [],
+        "usernames": {},
+        "stacks": {},
+        "contributions": {},
+        "community": [],
+        "hole_cards": {},
+        "phase": "waiting",
+        "player_actions": {},
+    }
+
 # ---------- Константы ----------
 BLIND_SMALL    = 1
 BLIND_BIG      = 2

--- a/table_manager.py
+++ b/table_manager.py
@@ -15,15 +15,47 @@ class TableManager:
         3) Рассылает новое состояние через WebSocket всем подключённым
         """
         # 1) Удаляем из game_states
-        state = game_states.get(table_id)
+        state = game_engine.game_states.get(table_id)
         if state is not None:
             idx = state["player_seats"].pop(player_id, None)
             if idx is not None and 0 <= idx < len(state["seats"]):
                 state["seats"][idx] = None
 
         # 2) HTTP-логика: seat_map и БД
-        http_leave_table(player_id, table_id)
+        tables.leave_table(table_id, player_id)
 
         # 3) Broadcast через WS
-        await broadcast_state(table_id)
+        await game_ws.broadcast_state(table_id)
+        return {"status": "ok"}
+
+    @staticmethod
+    async def join(player_id: str, table_id: int, deposit: int, seat_idx: int):
+        """Универсальная посадка игрока за стол."""
+        cfg = tables.get_table_config(table_id)
+        if deposit < cfg["min_deposit"] or deposit > cfg["max_deposit"]:
+            from fastapi import HTTPException
+            raise HTTPException(
+                status_code=400,
+                detail=f"Deposit {deposit} not in [{cfg['min_deposit']}, {cfg['max_deposit']}] range",
+            )
+
+        tables.join_table(player_id, table_id, deposit, seat_idx)
+
+        state = game_engine.game_states.setdefault(
+            table_id, game_engine.create_new_state(cfg["max_players"])
+        )
+
+        if state["seats"][seat_idx] is not None:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail="Seat already taken")
+
+        state["seats"][seat_idx] = player_id
+        state["player_seats"][player_id] = seat_idx
+        state["stacks"][player_id] = deposit
+        state["players"] = [p for p in state["seats"] if p]
+
+        if len(state["players"]) >= game_engine.MIN_PLAYERS and state.get("phase") != "pre-flop":
+            game_engine.start_hand(table_id)
+
+        await game_ws.broadcast_state(table_id)
         return {"status": "ok"}

--- a/tables.py
+++ b/tables.py
@@ -9,6 +9,7 @@ BLINDS = {
     2: (2, 4, 200),
     3: (5, 10, 500),
 }
+MAX_PLAYERS = 6
 
 # Минимальное число игроков для старта
 MIN_PLAYERS = 2
@@ -35,6 +36,18 @@ def list_tables() -> list:
     return out
 
 
+def get_table_config(table_id: int) -> dict:
+    """Возвращает конфигурацию стола."""
+    sb, bb, bi = BLINDS.get(table_id, (1, 2, 100))
+    return {
+        "small_blind": sb,
+        "big_blind": bb,
+        "min_deposit": bi,
+        "max_deposit": bi * 10,
+        "max_players": MAX_PLAYERS,
+    }
+
+
 def create_table(level: int) -> dict:
     """
     Создает новый стол по заданному уровню. Возвращает его параметры.
@@ -55,16 +68,11 @@ def create_table(level: int) -> dict:
     }
 
 
-def join_table(table_id: int, user_id: str) -> dict:
-    """
-    Добавляет пользователя за стол или обновляет его присутствие.
-    Возвращает статус и список игроков.
-    """
+def join_table(user_id: str, table_id: int, deposit: int, seat_idx: int) -> dict:
+    """Регистрирует игрока в seat_map."""
     users = seat_map.setdefault(table_id, [])
-    # Если пользователь уже за столом, удаляем старую запись для переподключения
-    if user_id in users:
-        users.remove(user_id)
-    users.append(user_id)
+    if user_id not in users:
+        users.append(user_id)
     return {"status": "ok", "players": users}
 
 

--- a/webapp/game.html
+++ b/webapp/game.html
@@ -11,6 +11,7 @@
   <header>
     <h1>Стол <span id="table-id"></span></h1>
   </header>
+  <div id="deposit-range"></div>
     <button id="leave-btn" title="Покинуть стол"></button>
   <div id="game-info">
     <div id="status"></div>

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -15,11 +15,19 @@ export async function createTable(level) {
   return await res.json();
 }
 
-export async function joinTable(tableId, userId) {
+export async function joinTable(tableId, userId, deposit, seatIdx) {
   const res = await fetch(`${BASE}/api/join?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deposit, seat_idx: seatIdx })
   });
   if (!res.ok) throw new Error(`joinTable error ${res.status}`);
+  return await res.json();
+}
+
+export async function getTableConfig(tableId) {
+  const res = await fetch(`${BASE}/api/table_config?table_id=${tableId}`);
+  if (!res.ok) throw new Error(`getTableConfig error ${res.status}`);
   return await res.json();
 }
 
@@ -36,5 +44,10 @@ export async function getGameState(tableId) {
 }
 
 export default {
-  listTables, createTable, joinTable, getBalance, getGameState
+  listTables,
+  createTable,
+  joinTable,
+  getBalance,
+  getGameState,
+  getTableConfig,
 };

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -149,11 +149,14 @@ export function renderTable(tableState, userId) {
 
 // Сажаем игрока на место (используем глобальные window.currentTableId/ currentUserId)
 function joinSeat(seatId) {
-  fetch(
-    `/api/join-seat?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}`,
-    { method: 'POST' }
-  ).then(() => {
-    reloadGameState();
+  const cfg = window.tableConfig || {};
+  const val = prompt(`Deposit (${cfg.min_deposit}-${cfg.max_deposit})`);
+  const dep = parseInt(val, 10);
+  if (!dep || dep < cfg.min_deposit || dep > cfg.max_deposit) return;
+  fetch(`/api/join?table_id=${window.currentTableId}&user_id=${window.currentUserId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deposit: dep, seat_idx: seatId })
   });
 }
 

--- a/webapp/js/ui_game.js
+++ b/webapp/js/ui_game.js
@@ -25,9 +25,20 @@ const currentBetEl   = document.getElementById('current-bet');
 const actionsEl      = document.getElementById('actions');
 const leaveBtn       = document.getElementById('leave-btn');
 const pokerTableEl   = document.getElementById('poker-table');
+const depositRangeEl = document.getElementById('deposit-range');
 console.log('[ui_game] leaveBtn element:', leaveBtn);
 
 let ws;
+
+// Получаем конфигурацию стола
+window.tableConfig = {};
+fetch(`/api/table_config?table_id=${tableId}`)
+  .then(r => r.json())
+  .then(cfg => {
+    window.tableConfig = cfg;
+    if (depositRangeEl)
+      depositRangeEl.textContent = `Депозит: ${cfg.min_deposit}-${cfg.max_deposit}`;
+  });
 
 // Храним предыдущую улицу, чтобы сбрасывать авто-режимы при смене
 let lastRound = null;

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -1,4 +1,4 @@
-import { listTables, joinTable } from './api.js';
+import { listTables } from './api.js';
 
 const infoContainer = document.getElementById('info');
 const levelSelect   = document.getElementById('level-select');
@@ -71,8 +71,7 @@ async function loadTables() {
         <p>Бай-ин: ${t.buy_in} | Игроки: ${t.players}</p>
         <button class="join-btn">Играть</button>
       `;
-      card.querySelector('.join-btn').addEventListener('click', async () => {
-        await joinTable(t.id, userId);
+      card.querySelector('.join-btn').addEventListener('click', () => {
         const uidParam = encodeURIComponent(userId);
         const unameParam = encodeURIComponent(username);
         window.open(


### PR DESCRIPTION
## Summary
- implement create_new_state in `game_engine`
- add table configuration helpers in `tables`
- implement `TableManager.join` with seat and deposit logic
- expose `/api/table_config` and update join endpoint
- remove auto seating from websocket handler
- adjust frontend to allow choosing seat and deposit

## Testing
- `python3 -m py_compile server.py table_manager.py tables.py game_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_684a41a1f2dc832c83f9c531ddef6232