### PR TITLE
Add buy-in support

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -12,14 +12,14 @@ def init_schema():
     cur.execute("""
         CREATE TABLE IF NOT EXISTS balances (
           user_id TEXT PRIMARY KEY,
-          balance INTEGER NOT NULL
+          balance REAL NOT NULL
         );
     """)
     conn.commit()
     cur.close()
     conn.close()
 
-def get_balance_db(user_id: str) -> int:
+def get_balance_db(user_id: str) -> float:
     conn = get_conn()
     cur = conn.cursor()
     cur.execute("SELECT balance FROM balances WHERE user_id = %s", (user_id,))
@@ -37,7 +37,7 @@ def get_balance_db(user_id: str) -> int:
     conn.close()
     return bal
 
-def set_balance_db(user_id: str, balance: int):
+def set_balance_db(user_id: str, balance: float):
     conn = get_conn()
     cur = conn.cursor()
     # PostgreSQL UPSERT: INSERT ... ON CONFLICT ... DO UPDATE
@@ -53,3 +53,9 @@ def set_balance_db(user_id: str, balance: int):
     conn.commit()
     cur.close()
     conn.close()
+
+
+def update_balance_db(user_id: str, delta: float):
+    """Прибавляет delta к текущему балансу пользователя."""
+    bal = get_balance_db(user_id)
+    set_balance_db(user_id, bal + delta)

--- a/game_ws.py
+++ b/game_ws.py
@@ -3,6 +3,8 @@ import time
 import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from game_engine import game_states, connections, start_hand, apply_action, DECISION_TIME, RESULT_DELAY
+from db_utils import get_balance_db, update_balance_db
+from tables import get_table_config, leave_table
 
 router = APIRouter()
 MIN_PLAYERS = 2
@@ -83,23 +85,14 @@ async def ws_game(websocket: WebSocket, table_id: int):
     player_seats = state.setdefault("player_seats", {})
     usernames = state.setdefault("usernames", {})
     players = state.setdefault("players", [])
-
-    # Проверяем: уже сидит или нет
-    already_seated = any(occupant == uid for occupant in seats)
-    # Садим нового игрока, если не сидит
-    if not already_seated:
-        for s in range(N):
-            if seats[s] is None:
-                seats[s] = uid
-                player_seats[uid] = s
-                break
+    stacks = state.setdefault("stacks", {})
 
     usernames[uid] = username
-    players = [u for u in seats if u]
-    state["players"] = players
     state["usernames"] = usernames
     state["seats"] = seats
     state["player_seats"] = player_seats
+    players = [u for u in seats if u]
+    state["players"] = players
 
     # Добавляем соединение
     if websocket not in conns:
@@ -126,10 +119,69 @@ async def ws_game(websocket: WebSocket, table_id: int):
             except WebSocketDisconnect:
                 break
             msg = json.loads(data)
-            pid = str(msg.get("user_id"))
             action = msg.get("action")
-            amount = int(msg.get("amount", 0) or 0)
 
+            if action == "get_table_info":
+                cfg = get_table_config(table_id)
+                await websocket.send_json({
+                    "action": "table_info",
+                    "table_id": table_id,
+                    "min_buy_in": cfg["min_buy_in"],
+                    "max_buy_in": cfg["max_buy_in"],
+                })
+                continue
+
+            if action == "sit":
+                seat = int(msg.get("seat", -1))
+                buy_in = float(msg.get("buy_in", 0))
+                cfg = get_table_config(table_id)
+                if seat < 0 or seat >= N or seats[seat] is not None:
+                    await websocket.send_json({"error": "seat_unavailable"})
+                    continue
+                if not (cfg["min_buy_in"] <= buy_in <= cfg["max_buy_in"]):
+                    await websocket.send_json({"error": "invalid_buy_in"})
+                    continue
+                balance = get_balance_db(uid)
+                if balance < buy_in:
+                    await websocket.send_json({"error": "insufficient_balance"})
+                    continue
+                update_balance_db(uid, -buy_in)
+                seats[seat] = uid
+                player_seats[uid] = seat
+                stacks[uid] = buy_in
+                players = [u for u in seats if u]
+                state["players"] = players
+                state["stacks"] = stacks
+                await websocket.send_json({
+                    "action": "sit_ok",
+                    "seat": seat,
+                    "buy_in": buy_in,
+                    "stack": buy_in,
+                })
+                if len(players) >= MIN_PLAYERS and state.get("phase") != "pre-flop":
+                    start_hand(table_id)
+                await broadcast(table_id)
+                continue
+
+            if action == "leave":
+                stack = stacks.pop(uid, 0)
+                seat_idx = player_seats.pop(uid, None)
+                if seat_idx is not None and 0 <= seat_idx < N and seats[seat_idx] == uid:
+                    seats[seat_idx] = None
+                players = [u for u in seats if u]
+                state["players"] = players
+                update_balance_db(uid, stack)
+                try:
+                    leave_table(table_id, uid)
+                except Exception:
+                    pass
+                await websocket.send_json({"action": "leave_ok", "returned_balance": stack})
+                await broadcast(table_id)
+                continue
+
+            # Остальные игровые действия
+            pid = str(msg.get("user_id", uid))
+            amount = int(msg.get("amount", 0) or 0)
             apply_action(table_id, pid, action, amount)
 
             s = game_states[table_id]
@@ -143,19 +195,24 @@ async def ws_game(websocket: WebSocket, table_id: int):
         # Нормальное закрытие клиентом
         pass
     finally:
-        # Освобождаем место и чистим все связи
+        # Освобождаем место и чистим связи, возвращаем стек
+        stack = stacks.pop(uid, 0)
         if uid in player_seats:
-            seat_idx = player_seats[uid]
+            seat_idx = player_seats.pop(uid)
             if 0 <= seat_idx < N and seats[seat_idx] == uid:
                 seats[seat_idx] = None
-            del player_seats[uid]
         usernames.pop(uid, None)
-        if uid in players:
-            players.remove(uid)
-        state["players"] = [u for u in seats if u]
+        players = [u for u in seats if u]
+        state["players"] = players
         state["usernames"] = usernames
         state["seats"] = seats
         state["player_seats"] = player_seats
+        update_balance_db(uid, stack)
+        if stack:
+            try:
+                leave_table(table_id, uid)
+            except Exception:
+                pass
         await broadcast(table_id)
         if websocket in conns:
             conns.remove(websocket)

--- a/tables.py
+++ b/tables.py
@@ -3,55 +3,53 @@ from fastapi import HTTPException
 from game_data import seat_map
 from game_engine import game_states
 
-# Глобальный словарь с настройками блайндов по уровням
-BLINDS = {
-    1: (1, 2, 100),
-    2: (2, 4, 200),
-    3: (5, 10, 500),
+# Конфигурация столов: размеры блайндов и лимиты бай-ина
+TABLE_CONFIGS = {
+    1: {"small_blind": 1, "big_blind": 2, "min_buy_in": 2.5, "max_buy_in": 15},
+    2: {"small_blind": 2, "big_blind": 4, "min_buy_in": 12.5, "max_buy_in": 50},
+    3: {"small_blind": 5, "big_blind": 10, "min_buy_in": 75, "max_buy_in": 500},
 }
 
 # Минимальное число игроков для старта
 MIN_PLAYERS = 2
 
 # Инициализируем состояния для предустановленных столов
-for tid in BLINDS.keys():
+for tid in TABLE_CONFIGS.keys():
     game_states.setdefault(tid, {})
 
 
 def list_tables() -> list:
-    """
-    Возвращает список всех столов с параметрами и числом игроков.
-    """
+    """Возвращает список всех столов с параметрами и числом игроков."""
     out = []
-    for tid, (sb, bb, bi) in BLINDS.items():
+    for tid, cfg in TABLE_CONFIGS.items():
         users = seat_map.get(tid, [])
         out.append({
             "id": tid,
-            "small_blind": sb,
-            "big_blind": bb,
-            "buy_in": bi,
-            "players": len(users)
+            "small_blind": cfg["small_blind"],
+            "big_blind": cfg["big_blind"],
+            "min_buy_in": cfg["min_buy_in"],
+            "max_buy_in": cfg["max_buy_in"],
+            "players": len(users),
         })
     return out
 
 
 def create_table(level: int) -> dict:
-    """
-    Создает новый стол по заданному уровню. Возвращает его параметры.
-    """
-    if level not in BLINDS:
+    """Создает новый стол по заданному уровню. Возвращает его параметры."""
+    if level not in TABLE_CONFIGS:
         raise HTTPException(status_code=400, detail="Invalid level")
-    new_id = max(BLINDS.keys(), default=0) + 1
-    sb, bb, bi = BLINDS[level]
-    BLINDS[new_id] = (sb, bb, bi)
+    new_id = max(TABLE_CONFIGS.keys(), default=0) + 1
+    cfg = TABLE_CONFIGS[level]
+    TABLE_CONFIGS[new_id] = cfg.copy()
     seat_map[new_id] = []
     game_states[new_id] = {}
     return {
         "id": new_id,
-        "small_blind": sb,
-        "big_blind": bb,
-        "buy_in": bi,
-        "players": 0
+        "small_blind": cfg["small_blind"],
+        "big_blind": cfg["big_blind"],
+        "min_buy_in": cfg["min_buy_in"],
+        "max_buy_in": cfg["max_buy_in"],
+        "players": 0,
     }
 
 
@@ -88,3 +86,11 @@ def get_balance(table_id: int, user_id: str) -> dict:
     """
     stacks = game_states.get(table_id, {}).get("stacks", {})
     return {"balance": stacks.get(user_id, 0)}
+
+
+def get_table_config(table_id: int) -> dict:
+    """Возвращает конфигурацию указанного стола."""
+    cfg = TABLE_CONFIGS.get(table_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return cfg.copy()

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -149,12 +149,14 @@ export function renderTable(tableState, userId) {
 
 // Сажаем игрока на место (используем глобальные window.currentTableId/ currentUserId)
 function joinSeat(seatId) {
-  fetch(
-    `/api/join-seat?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}`,
-    { method: 'POST' }
-  ).then(() => {
-    reloadGameState();
-  });
+  const ws = window.gameWebSocket;
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  const info = window.currentTableInfo || {};
+  const min = info.min_buy_in || 0;
+  const max = info.max_buy_in || 0;
+  const buy = parseFloat(prompt(`Buy-in (${min}-${max})`, String(min))) || 0;
+  if (buy < min || buy > max) return;
+  ws.send(JSON.stringify({ action: 'sit', seat: seatId, buy_in: buy }));
 }
 
 // На resize — перерисовка

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -68,7 +68,7 @@ async function loadTables() {
       card.innerHTML = `
         <h3>Стол ${t.id}</h3>
         <p>SB/BB: ${t.small_blind}/${t.big_blind}</p>
-        <p>Бай-ин: ${t.buy_in} | Игроки: ${t.players}</p>
+        <p>Buy-in: ${t.min_buy_in} - ${t.max_buy_in} | Игроки: ${t.players}</p>
         <button class="join-btn">Играть</button>
       `;
       card.querySelector('.join-btn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add buy-in limits to table configs
- adjust DB schema to use REAL balance and support balance updates
- implement buy-in sit/leave logic in WebSocket server
- keep account balance on player leave
- show buy-in limits in lobby and handle sit/buy-in on frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855a2e78560832c86c51fa1ab6b67e1