### PR TITLE
Implement observer mode with delayed buy-in

### DIFF
--- a/game_ws.py
+++ b/game_ws.py
@@ -71,6 +71,7 @@ async def _auto_restart(table_id: int):
 
 @router.websocket("/ws/game/{table_id}")
 async def ws_game(websocket: WebSocket, table_id: int):
+    role = websocket.query_params.get("role", "observer")
     await websocket.accept()
 
     uid = websocket.query_params.get("user_id")
@@ -84,32 +85,36 @@ async def ws_game(websocket: WebSocket, table_id: int):
     usernames = state.setdefault("usernames", {})
     players = state.setdefault("players", [])
 
-    # Проверяем: уже сидит или нет
-    already_seated = any(occupant == uid for occupant in seats)
-    # Садим нового игрока, если не сидит
-    if not already_seated:
-        for s in range(N):
-            if seats[s] is None:
-                seats[s] = uid
-                player_seats[uid] = s
-                break
+    if role == "player":
+        already_seated = any(occupant == uid for occupant in seats)
+        if not already_seated:
+            seat_found = False
+            for s in range(N):
+                if seats[s] is None:
+                    seats[s] = uid
+                    player_seats[uid] = s
+                    seat_found = True
+                    break
+            if not seat_found:
+                # no free seats
+                await websocket.close(code=1013)
+                return
 
     usernames[uid] = username
-    players = [u for u in seats if u]
-    state["players"] = players
+    if role == "player":
+        players = [u for u in seats if u]
+        state["players"] = players
+        state["seats"] = seats
+        state["player_seats"] = player_seats
     state["usernames"] = usernames
-    state["seats"] = seats
-    state["player_seats"] = player_seats
 
     # Добавляем соединение
     if websocket not in conns:
         conns.append(websocket)
-    if len(conns) > N:
-        await websocket.close(code=1013)
-        return
+    websocket.role = role
 
     # Старт новой раздачи если нужно
-    if len(players) >= MIN_PLAYERS and state.get("phase") != "pre-flop":
+    if role == "player" and len(players) >= MIN_PLAYERS and state.get("phase") != "pre-flop":
         start_hand(table_id)
 
     await broadcast(table_id)
@@ -144,18 +149,19 @@ async def ws_game(websocket: WebSocket, table_id: int):
         pass
     finally:
         # Освобождаем место и чистим все связи
-        if uid in player_seats:
-            seat_idx = player_seats[uid]
-            if 0 <= seat_idx < N and seats[seat_idx] == uid:
-                seats[seat_idx] = None
-            del player_seats[uid]
-        usernames.pop(uid, None)
-        if uid in players:
-            players.remove(uid)
-        state["players"] = [u for u in seats if u]
-        state["usernames"] = usernames
-        state["seats"] = seats
-        state["player_seats"] = player_seats
-        await broadcast(table_id)
+        if role == "player":
+            if uid in player_seats:
+                seat_idx = player_seats[uid]
+                if 0 <= seat_idx < N and seats[seat_idx] == uid:
+                    seats[seat_idx] = None
+                del player_seats[uid]
+            usernames.pop(uid, None)
+            if uid in players:
+                players.remove(uid)
+            state["players"] = [u for u in seats if u]
+            state["usernames"] = usernames
+            state["seats"] = seats
+            state["player_seats"] = player_seats
+            await broadcast(table_id)
         if websocket in conns:
             conns.remove(websocket)

--- a/server.py
+++ b/server.py
@@ -5,7 +5,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from db_utils import init_schema, get_balance_db, set_balance_db
-from tables import list_tables, create_table, join_table, leave_table, get_balance
+from tables import (
+    list_tables,
+    create_table,
+    join_table,
+    leave_table,
+    get_balance,
+    observe_table,
+)
 from game_ws import router as game_router, broadcast
 from game_engine import game_states
 
@@ -43,6 +50,15 @@ def get_tables(level: str = Query(...)):
 def create_table_endpoint(level: int = Query(...)):
     """Создать новый стол"""
     return create_table(level)
+
+
+@app.get("/api/observe")
+def observe_table_endpoint(
+    table_id: int = Query(...),
+    user_id: str = Query(...),
+):
+    """Позволяет подключиться как наблюдатель и получить базовую информацию."""
+    return observe_table(table_id, user_id)
 
 @app.post("/api/join")
 def join_table_endpoint(

--- a/tables.py
+++ b/tables.py
@@ -60,6 +60,24 @@ def create_table(level: int) -> dict:
     }
 
 
+def observe_table(table_id: int, user_id: str) -> dict:
+    """Return basic table info for observer connection."""
+    if table_id not in BLINDS:
+        raise HTTPException(status_code=404, detail="table not found")
+
+    sb, bb, _ = BLINDS[table_id]
+    users = seat_map.get(table_id, [])
+    return {
+        "table_id": table_id,
+        "small_blind": sb,
+        "big_blind": bb,
+        "min_buy_in": MIN_BUY_IN,
+        "max_buy_in": MAX_BUY_IN,
+        "players": users,
+        "ws_token": f"{table_id}:{user_id}",
+    }
+
+
 def join_table(table_id: int, user_id: str, buy_in: float) -> dict:
     """
     Добавляет пользователя за стол или обновляет его присутствие.
@@ -83,7 +101,12 @@ def join_table(table_id: int, user_id: str, buy_in: float) -> dict:
     stacks[user_id] = buy_in
 
     users.append(user_id)
-    return {"status": "ok", "players": users, "buy_in": buy_in}
+    return {
+        "status": "ok",
+        "players": users,
+        "buy_in": buy_in,
+        "stack": stacks[user_id],
+    }
 
 
 def leave_table(table_id: int, user_id: str) -> dict:

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -45,3 +45,12 @@ def test_successful_join():
     assert resp.status_code == 200
     data = resp.json()
     assert data["buy_in"] == 5
+    assert data["stack"] == 5
+
+
+def test_observe_endpoint():
+    resp = client.get("/api/observe", params={"table_id": 1, "user_id": "u1"})
+    assert resp.status_code == 200
+    info = resp.json()
+    assert "ws_token" in info
+    assert info["min_buy_in"] == tables.MIN_BUY_IN

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -23,6 +23,12 @@ export async function joinTable(tableId, userId, buyIn) {
   return await res.json();
 }
 
+export async function observeTable(tableId, userId) {
+  const res = await fetch(`${BASE}/api/observe?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`);
+  if (!res.ok) throw new Error(`observeTable error ${res.status}`);
+  return await res.json();
+}
+
 export async function getBalance(userId) {
   const res = await fetch(`${BASE}/api/balance?user_id=${encodeURIComponent(userId)}`);
   if (!res.ok) throw new Error(`getBalance error ${res.status}`);
@@ -36,5 +42,10 @@ export async function getGameState(tableId) {
 }
 
 export default {
-  listTables, createTable, joinTable, getBalance, getGameState
+  listTables,
+  createTable,
+  joinTable,
+  observeTable,
+  getBalance,
+  getGameState,
 };

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -148,8 +148,8 @@ export function renderTable(tableState, userId) {
 }
 
 // Сажаем игрока на место (используем глобальные window.currentTableId/ currentUserId)
-const MIN_BUY_IN = 3;
-const MAX_BUY_IN = 7;
+let MIN_BUY_IN = 3;
+let MAX_BUY_IN = 7;
 
 function joinSeat(seatId) {
   const modal   = document.getElementById('buyin-modal');
@@ -157,6 +157,11 @@ function joinSeat(seatId) {
   const confirm = document.getElementById('buyin-confirm');
   const cancel  = document.getElementById('buyin-cancel');
   const errorEl = document.getElementById('buyin-error');
+
+  if (window.tableConfig) {
+    MIN_BUY_IN = window.tableConfig.min_buy_in;
+    MAX_BUY_IN = window.tableConfig.max_buy_in;
+  }
 
   input.min = MIN_BUY_IN;
   input.max = MAX_BUY_IN;
@@ -200,7 +205,7 @@ function joinSeat(seatId) {
       }
 
       modal.style.display = 'none';
-      if (window.afterJoin) window.afterJoin();
+      if (window.afterJoin) window.afterJoin('player');
     } catch (e) {
       errorEl.textContent = 'Ошибка соединения';
     }

--- a/webapp/js/ws.js
+++ b/webapp/js/ws.js
@@ -8,11 +8,12 @@ import { getGameState } from './api.js';
  * @param {function(MessageEvent):void} onMessage
  * @returns {WebSocket}
  */
-export function createWebSocket(tableId, userId, username, onMessage) {
+export function createWebSocket(tableId, userId, username, role, onMessage) {
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const url = `${protocol}://${window.location.host}/ws/game/${tableId}` +
               `?user_id=${encodeURIComponent(userId)}` +
-              `&username=${encodeURIComponent(username)}`;
+              `&username=${encodeURIComponent(username)}` +
+              `&role=${encodeURIComponent(role || 'observer')}`;
 
   const ws = new WebSocket(url);
 


### PR DESCRIPTION
## Summary
- add `/api/observe` endpoint and observer table utility
- allow WebSocket role selection for observers and players
- connect as observer first on the client and join later with buy‑in
- update UI logic for observer mode
- extend API helpers and tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602797b9a0832c9760393bd96c3e0c