### PR TITLE
Implement game state API and auth improvements

### DIFF
--- a/server.py
+++ b/server.py
@@ -44,7 +44,7 @@ app.include_router(game_router)
 @app.get("/api/tables")
 def get_tables(level: str = Query(...), auth: None = Depends(require_auth)):
     """Получить список столов"""
-    return {"tables": list_tables()}
+    return {"tables": [t for t in list_tables() if t["level"] == level]}
 
 @app.post("/api/tables")
 def create_table_endpoint(level: str = Query(...), auth: None = Depends(require_auth)):
@@ -99,6 +99,14 @@ def get_balance_legacy(
 ):
     """(Legacy) Получить баланс игрока для старого кода"""
     return get_balance(table_id, user_id)
+
+
+@app.get("/api/game_state")
+def api_game_state(table_id: int = Query(...), auth: None = Depends(require_auth)):
+    state = game_states.get(table_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="No game state")
+    return state
 
 # Статика фронтенда
 app.mount("/", StaticFiles(directory="webapp", html=True), name="webapp")

--- a/webapp/game.html
+++ b/webapp/game.html
@@ -28,6 +28,12 @@
 </div>
   </div>
 
+  <script>
+    window.initData = window.Telegram?.WebApp?.initData || '';
+    if (window.Telegram?.WebApp?.ready) {
+      window.Telegram.WebApp.ready();
+    }
+  </script>
   <script type="module" src="/js/ui_game.js"></script>
 </body>
 </html>

--- a/webapp/js/ws.js
+++ b/webapp/js/ws.js
@@ -25,7 +25,9 @@ export function createWebSocket(tableId, userId, seat, onMessage) {
 
 // Fallback-поллинг через HTTP: обновление состояния каждые 2 секунды
 export function startPolling(tableId, userId, onState) {
+  let stopped = false;
   async function poll() {
+    if (stopped) return;
     try {
       const state = await getGameState(tableId);
       onState({ data: JSON.stringify(state) });
@@ -35,4 +37,5 @@ export function startPolling(tableId, userId, onState) {
     setTimeout(poll, 2000);
   }
   poll();
+  return () => { stopped = true; };
 }


### PR DESCRIPTION
## Summary
- expose `/api/game_state` to fetch a table's current state
- filter `/api/tables` by level
- inject Telegram initData on the game page
- preload game state and poll before taking a seat
- allow stopping HTTP polling once WebSocket connects

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m uvicorn server:app --port 8001 --reload` *(fails: OperationalError: connection to server on socket '/var/run/postgresql/.s.PGSQL.5432' failed)*

------
https://chatgpt.com/codex/tasks/task_e_687bb49debbc832caf54b824a2ba449a