### PR TITLE
Fix lobby auth and table filtering

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -36,9 +36,9 @@
     <label>
       Уровень:
       <select id="level-select">
-        <option value="1">Low</option>
-        <option value="2">Medium</option>
-        <option value="3">High</option>
+        <option value="low">Low</option>
+        <option value="mid">Medium</option>
+        <option value="vip">High</option>
       </select>
     </label>
   </div>
@@ -64,6 +64,12 @@
     });
   </script>
 
+  <script>
+    // подписанные данные из Telegram WebApp или пустая строка
+    window.initData = window.Telegram?.WebApp?.initData || '';
+    // оповестить WebApp, что мы готовы к работе
+    window.Telegram?.WebApp?.ready();
+  </script>
   <script type="module" src="js/ui_lobby.js"></script>
 </body>
 </html>

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -2,42 +2,57 @@
 const BASE = '';
 
 export async function listTables(level) {
-  const res = await fetch(`${BASE}/api/tables?level=${encodeURIComponent(level)}`, {
-    headers: { 'Authorization': window.initData || '' }
+  const url = `${BASE}/api/tables?level=${encodeURIComponent(level)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
   });
   if (!res.ok) throw new Error(`listTables error ${res.status}`);
   return await res.json();
 }
 
 export async function createTable(level) {
-  const res = await fetch(`${BASE}/api/tables?level=${encodeURIComponent(level)}`, {
+  const url = `${BASE}/api/tables?level=${encodeURIComponent(level)}`;
+  const res = await fetch(url, {
     method: 'POST',
-    headers: { 'Authorization': window.initData || '' }
+    headers: {
+      Authorization: window.initData,
+    }
   });
   if (!res.ok) throw new Error(`createTable error ${res.status}`);
   return await res.json();
 }
 
 export async function joinTable(tableId, userId, seat, deposit) {
-  const res = await fetch(`${BASE}/api/join?table_id=${tableId}&user_id=${encodeURIComponent(userId)}&seat=${seat}&deposit=${deposit}`, {
+  const url = `${BASE}/api/join?table_id=${tableId}&user_id=${encodeURIComponent(userId)}&seat=${seat}&deposit=${deposit}`;
+  const res = await fetch(url, {
     method: 'POST',
-    headers: { 'Authorization': window.initData || '' }
+    headers: {
+      Authorization: window.initData,
+    }
   });
   if (!res.ok) throw new Error(`joinTable error ${res.status}`);
   return await res.json();
 }
 
 export async function getBalance(tableId, userId) {
-  const res = await fetch(`${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`, {
-    headers: { 'Authorization': window.initData || '' }
+  const url = `${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
   });
   if (!res.ok) throw new Error(`getBalance error ${res.status}`);
   return await res.json();
 }
 
 export async function getGameState(tableId) {
-  const res = await fetch(`${BASE}/api/game_state?table_id=${tableId}`, {
-    headers: { 'Authorization': window.initData || '' }
+  const url = `${BASE}/api/game_state?table_id=${tableId}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
   });
   if (!res.ok) throw new Error(`getGameState error ${res.status}`);
   return await res.json();

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -155,10 +155,11 @@ function joinSeat(seatId) {
     customJoinHandler(seatId);
     return;
   }
-  fetch(
-    `/api/join-seat?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}`,
-    { method: 'POST' }
-  ).then(() => {
+  const url = `/api/join-seat?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}`;
+  fetch(url, {
+    method: 'POST',
+    headers: { Authorization: window.initData }
+  }).then(() => {
     reloadGameState && reloadGameState();
   });
 }

--- a/webapp/js/ui_game.js
+++ b/webapp/js/ui_game.js
@@ -61,10 +61,11 @@ setJoinHandler(async seatId => {
     return;
   }
   try {
-    const res = await fetch(
-      `/api/join?table_id=${tableId}&user_id=${userId}&seat=${seatId}&deposit=${amount}`,
-      { method: 'POST', headers: { 'Authorization': window.initData || '' } }
-    );
+    const url = `/api/join?table_id=${tableId}&user_id=${userId}&seat=${seatId}&deposit=${amount}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: window.initData }
+    });
     if (!res.ok) {
       alert('Seat taken or unauthorized');
       return;
@@ -377,10 +378,11 @@ if (!leaveBtn) {
 
     // 2) Оповещаем сервер о выходе
     try {
-      const res = await fetch(
-        `/api/leave?table_id=${tableId}&user_id=${userId}`,
-        { method: 'POST', headers: { 'Authorization': window.initData || '' } }
-      );
+      const url = `/api/leave?table_id=${tableId}&user_id=${userId}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: window.initData }
+      });
       console.log('[ui_game] /api/leave status:', res.status);
     } catch (e) {
       console.error('[ui_game] leave fetch error', e);

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -2,10 +2,11 @@ import { listTables } from './api.js';
 
 window.initData = window.Telegram?.WebApp?.initData || '';
 
-const infoContainer = document.getElementById('info');
-const levelSelect   = document.getElementById('level-select');
-const usernameEl    = document.getElementById('username');
-const balanceSpan   = document.getElementById('current-balance'); // Для баланса
+document.addEventListener('DOMContentLoaded', () => {
+  const infoContainer = document.getElementById('info');
+  const levelSelect   = document.getElementById('level-select');
+  const usernameEl    = document.getElementById('username');
+  const balanceSpan   = document.getElementById('current-balance'); // Для баланса
 
 // Генератор «авто-ID» на случай, если не залогинились через Telegram
 function generateId() {
@@ -48,7 +49,8 @@ const { uid: userId, uname: username } = getUserInfo();
 
 // ======= Баланс =======
 if (balanceSpan) {
-  fetch(`/api/balance?user_id=${userId}`, { headers: { 'Authorization': window.initData || '' } })
+  const url = `/api/balance?user_id=${userId}`;
+  fetch(url, { headers: { Authorization: window.initData } })
     .then(res => res.json())
     .then(data => {
       balanceSpan.innerText = `${data.balance} USDT`;
@@ -59,12 +61,16 @@ if (balanceSpan) {
 }
 
 // Загрузка списка столов
-async function loadTables() {
-  infoContainer.textContent = 'Загрузка…';
-  try {
-    const { tables } = await listTables(levelSelect.value);
-    infoContainer.innerHTML = '';
-    tables.forEach(t => {
+  async function loadTables() {
+    infoContainer.textContent = 'Загрузка…';
+    try {
+      const { tables } = await listTables(levelSelect.value);
+      infoContainer.innerHTML = '';
+      if (!Array.isArray(tables) || tables.length === 0) {
+        infoContainer.textContent = 'Столы не найдены';
+        return;
+      }
+      tables.forEach(t => {
       const card = document.createElement('div');
       card.className = 'table-card';
       card.innerHTML = `
@@ -83,10 +89,12 @@ async function loadTables() {
       });
       infoContainer.appendChild(card);
     });
-  } catch (err) {
-    infoContainer.textContent = 'Ошибка загрузки столов!';
+    } catch (err) {
+      console.error('loadTables error', err);
+      infoContainer.textContent = 'Ошибка загрузки столов!';
+    }
   }
-}
 
-levelSelect.addEventListener('change', loadTables);
-loadTables();
+  levelSelect.addEventListener('change', loadTables);
+  loadTables();
+});


### PR DESCRIPTION
## Summary
- reinstate strict Authorization validation
- require header for `/api/tables` and `/api/balance`
- update table level values to strings
- load lobby code after DOM is ready and log fetch errors

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_687bbbdbfbe8832c81e79e6e6fa6f0e7