### PR TITLE
Fix lobby auth and DOM init

### DIFF
--- a/server.py
+++ b/server.py
@@ -44,8 +44,13 @@ app.include_router(game_router)
 
 # API для игровых столов
 @app.get("/api/tables")
-def get_tables(level: str = Query(...)):
+def get_tables(
+    level: str = Query(...),
+    authorization: str = Header(..., alias="Authorization"),
+):
     """Получить список столов"""
+    if not validate_telegram_init_data(authorization):
+        raise HTTPException(status_code=401, detail="Unauthorized")
     all_tables = list_tables()
     filtered = [t for t in all_tables if t["level"] == level]
     return {"tables": filtered}
@@ -92,8 +97,13 @@ async def leave_table_endpoint(
     return result
 
 @app.get("/api/balance")
-async def api_get_balance(user_id: str = Query(...)):
+async def api_get_balance(
+    user_id: str = Query(...),
+    authorization: str = Header(..., alias="Authorization"),
+):
     """Возвращает текущий баланс игрока из БД."""
+    if not validate_telegram_init_data(authorization):
+        raise HTTPException(status_code=401, detail="Unauthorized")
     bal = get_balance_db(user_id)
     return {"balance": bal}
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -36,9 +36,9 @@
     <label>
       Уровень:
       <select id="level-select">
-        <option value="1">Low</option>
-        <option value="2">Medium</option>
-        <option value="3">High</option>
+        <option value="low">Low</option>
+        <option value="mid">Medium</option>
+        <option value="vip">High</option>
       </select>
     </label>
   </div>

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -36,8 +36,8 @@ export async function joinTable(tableId, userId, seat, deposit) {
   return await res.json();
 }
 
-export async function getBalance(tableId, userId) {
-  const url = `${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`;
+export async function getBalance(userId) {
+  const url = `${BASE}/api/balance?user_id=${encodeURIComponent(userId)}`;
   const res = await fetch(url, {
     headers: {
       Authorization: window.initData,

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,27 +1,16 @@
 // webapp/js/app.js
 import * as api from './api.js';
-import { loadLobby } from './ui_lobby.js';
 import { initGameUI } from './ui_game.js';
+import { getUserInfo, initTelegramData } from './user.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const tg = window.Telegram?.WebApp;
-  window.initData = tg?.initData || '';
-  if (tg) tg.ready();
-
-  // 1) Получаем userId из Telegram-WebApp
-  let userId;
-  if (tg?.initDataUnsafe?.user?.id) {
-    userId = tg.initDataUnsafe.user.id;
-  } else {
-    const p = new URLSearchParams(location.search);
-    userId = p.get('user_id') || 'guest_' + Date.now();
-    console.warn('Тестовый userId:', userId);
-  }
+  initTelegramData();
+  const { userId, username } = getUserInfo();
 
   // 2) Отобразить в шапке
   const nameEl = document.getElementById('username');
-  if (nameEl) nameEl.textContent = userId;
-  api.getBalance(0, userId)
+  if (nameEl) nameEl.textContent = username;
+  api.getBalance(userId)
     .then(d => {
       const b = document.getElementById('current-balance');
       if (b) b.textContent = d.balance + ' USDT';
@@ -37,13 +26,11 @@ document.addEventListener('DOMContentLoaded', () => {
     initGameUI({ tableId, userId });
   } else {
     // — Лобби
-    const infoEl = document.getElementById('info');
-    const levelSelect = document.getElementById('level-select');
     document.querySelectorAll('.tab').forEach(tab => {
       tab.onclick = () => {
         document.querySelectorAll('.tab')
           .forEach(t => t.classList.toggle('active', t === tab));
-        loadLobby(levelSelect, infoEl, userId);
+        // ui_lobby.js self-initializes on DOMContentLoaded
       };
     });
     // Авто-клик на первую вкладку

--- a/webapp/js/ui_game.js
+++ b/webapp/js/ui_game.js
@@ -1,21 +1,18 @@
 import { createWebSocket, startPolling } from './ws.js';
 import { renderTable, setJoinHandler } from './table_render.js';
 import { getGameState } from './api.js';
+import { getUserInfo, initTelegramData } from './user.js';
 
-window.initData = window.Telegram?.WebApp?.initData || '';
+initTelegramData();
 
-console.log('[ui_game] loaded, params:', {
-  tableId: new URLSearchParams(window.location.search).get('table_id'),
-  userId: new URLSearchParams(window.location.search).get('user_id')
-});
+console.log('[ui_game] loaded');
 
 // --- Params ---
-const params   = new URLSearchParams(window.location.search);
-const tableId  = params.get('table_id');
-const userId   = params.get('user_id');
-const username = params.get('username') || userId;
-const minDeposit = parseFloat(params.get('min')) || 0;
-const maxDeposit = parseFloat(params.get('max')) || 0;
+const params      = new URLSearchParams(window.location.search);
+const tableId     = params.get('table_id');
+const { userId, username } = getUserInfo();
+const minDeposit  = parseFloat(params.get('min')) || 0;
+const maxDeposit  = parseFloat(params.get('max')) || 0;
 
 window.currentTableId = tableId;
 window.currentUserId  = userId;

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -1,93 +1,70 @@
 import { listTables } from './api.js';
+import { getUserInfo, initTelegramData } from './user.js';
 
-window.initData = window.Telegram?.WebApp?.initData || '';
+// DOM is not guaranteed to be ready when module is loaded
+// so wrap initialization in DOMContentLoaded
 
-const infoContainer = document.getElementById('info');
-const levelSelect   = document.getElementById('level-select');
-const usernameEl    = document.getElementById('username');
-const balanceSpan   = document.getElementById('current-balance'); // Для баланса
+document.addEventListener('DOMContentLoaded', () => {
+  initTelegramData();
 
-// Генератор «авто-ID» на случай, если не залогинились через Telegram
-function generateId() {
-  return 'user_' + [...crypto.getRandomValues(new Uint8Array(4))]
-    .map(b => b.toString(16).padStart(2, '0')).join('');
-}
+  const infoContainer = document.getElementById('info');
+  const levelSelect   = document.getElementById('level-select');
+  const usernameEl    = document.getElementById('username');
+  const balanceSpan   = document.getElementById('current-balance');
 
-// Получаем user_id и username из URL, localStorage или генерим новые
-function getUserInfo() {
-  const params = new URLSearchParams(window.location.search);
-  let uid = params.get('user_id') || localStorage.getItem('user_id');
-  let uname = params.get('username') || localStorage.getItem('username');
+  const { userId, username } = getUserInfo();
+  if (usernameEl) usernameEl.textContent = username;
 
-  // Сохраняем в localStorage, если пришло из URL
-  if (params.get('user_id')) {
-    localStorage.setItem('user_id', uid);
-  }
-  if (params.get('username')) {
-    localStorage.setItem('username', uname);
-  }
-
-  // Генерируем ID, если нет
-  if (!uid) {
-    uid = generateId();
-    localStorage.setItem('user_id', uid);
-  }
-  // Дефолт для username — это uid
-  if (!uname) {
-    uname = uid;
-    localStorage.setItem('username', uname);
-  }
-
-  // Отображаем в UI
-  usernameEl.textContent = uname;
-
-  return { uid, uname };
-}
-
-const { uid: userId, uname: username } = getUserInfo();
-
-// ======= Баланс =======
-if (balanceSpan) {
-  const url = `/api/balance?user_id=${userId}`;
-  fetch(url, { headers: { Authorization: window.initData } })
-    .then(res => res.json())
-    .then(data => {
-      balanceSpan.innerText = `${data.balance} USDT`;
-    })
-    .catch(() => {
-      balanceSpan.innerText = 'Ошибка';
-    });
-}
-
-// Загрузка списка столов
-async function loadTables() {
-  infoContainer.textContent = 'Загрузка…';
-  try {
-    const { tables } = await listTables(levelSelect.value);
-    infoContainer.innerHTML = '';
-    tables.forEach(t => {
-      const card = document.createElement('div');
-      card.className = 'table-card';
-      card.innerHTML = `
-        <h3>Стол ${t.id}</h3>
-        <p>SB/BB: ${t.small_blind}/${t.big_blind}</p>
-        <p>Бай-ин: ${t.buy_in} | Игроки: ${t.players}</p>
-        <button class="join-btn">Играть</button>
-      `;
-      card.querySelector('.join-btn').addEventListener('click', async () => {
-        const uidParam = encodeURIComponent(userId);
-        const unameParam = encodeURIComponent(username);
-        window.open(
-          `/game.html?table_id=${t.id}&user_id=${uidParam}&username=${unameParam}&min=${t.min_deposit}&max=${t.max_deposit}`,
-          '_blank'
-        );
+  // ======= Баланс =======
+  if (balanceSpan) {
+    const url = `/api/balance?user_id=${userId}`;
+    fetch(url, { headers: { Authorization: window.initData } })
+      .then(res => res.json())
+      .then(data => {
+        balanceSpan.innerText = `${data.balance} USDT`;
+      })
+      .catch(err => {
+        console.error(err);
+        balanceSpan.innerText = 'Ошибка';
       });
-      infoContainer.appendChild(card);
-    });
-  } catch (err) {
-    infoContainer.textContent = 'Ошибка загрузки столов!';
   }
-}
 
-levelSelect.addEventListener('change', loadTables);
-loadTables();
+  // Загрузка списка столов
+  async function loadTables() {
+    infoContainer.textContent = 'Загрузка…';
+    try {
+      const { tables } = await listTables(levelSelect.value);
+      infoContainer.innerHTML = '';
+      if (!tables || tables.length === 0) {
+        infoContainer.textContent = 'Столов нет';
+        return;
+      }
+      tables.forEach(t => {
+        const card = document.createElement('div');
+        card.className = 'table-card';
+        card.innerHTML = `
+          <h3>Стол ${t.id}</h3>
+          <p>SB/BB: ${t.small_blind}/${t.big_blind}</p>
+          <p>Бай-ин: ${t.buy_in} | Игроки: ${t.players}</p>
+          <button class="join-btn">Играть</button>
+        `;
+        card.querySelector('.join-btn').addEventListener('click', () => {
+          const uidParam = encodeURIComponent(userId);
+          const unameParam = encodeURIComponent(username);
+          window.open(
+            `/game.html?table_id=${t.id}&user_id=${uidParam}&username=${unameParam}` +
+            `&min=${t.min_deposit}&max=${t.max_deposit}`,
+            '_blank'
+          );
+        });
+        infoContainer.appendChild(card);
+      });
+    } catch (err) {
+      console.error(err);
+      infoContainer.textContent = 'Ошибка загрузки столов!';
+    }
+  }
+
+  levelSelect.addEventListener('change', loadTables);
+  loadTables();
+});

--- a/webapp/js/user.js
+++ b/webapp/js/user.js
@@ -1,0 +1,45 @@
+// webapp/js/user.js
+
+/**
+ * Initialize Telegram WebApp data and store it globally.
+ */
+export function initTelegramData() {
+  window.initData = window.Telegram?.WebApp?.initData || '';
+  if (window.Telegram?.WebApp?.ready) {
+    window.Telegram.WebApp.ready();
+  }
+}
+
+// Generate random user id if none provided
+function generateId() {
+  return 'user_' + [...crypto.getRandomValues(new Uint8Array(4))]
+    .map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Retrieve user_id and username from URL parameters or localStorage.
+ * If not present, generates a new id and stores it.
+ */
+export function getUserInfo() {
+  const params = new URLSearchParams(window.location.search);
+  let uid = params.get('user_id') || localStorage.getItem('user_id');
+  let uname = params.get('username') || localStorage.getItem('username');
+
+  if (params.get('user_id')) {
+    localStorage.setItem('user_id', uid);
+  }
+  if (params.get('username')) {
+    localStorage.setItem('username', uname);
+  }
+
+  if (!uid) {
+    uid = generateId();
+    localStorage.setItem('user_id', uid);
+  }
+  if (!uname) {
+    uname = uid;
+    localStorage.setItem('username', uname);
+  }
+
+  return { userId: uid, username: uname };
+}


### PR DESCRIPTION
## Summary
- verify init data signature on tables and balance endpoints
- add centralized user helpers
- load lobby UI after DOMContentLoaded
- pass Authorization header from frontend
- map table levels properly in lobby dropdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bc37f0b60832c80e94a52f6b44c95