### PR TITLE
Add table levels, Telegram auth and deposit logic

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,20 +1,30 @@
 import os, hashlib, hmac, urllib.parse
+from fastapi import Header, HTTPException
 
 
 def validate_telegram_init_data(init_data: str) -> bool:
     """Validate Telegram WebApp initData signature."""
     token = os.getenv("TELEGRAM_BOT_TOKEN") or os.getenv("BOT_TOKEN")
-    if not token:
+    if not token or not init_data:
         return False
-    parsed = urllib.parse.parse_qsl(init_data, keep_blank_values=True)
-    data_dict = dict(parsed)
-    hash_received = data_dict.get("hash")
+    pairs = urllib.parse.parse_qsl(init_data, keep_blank_values=True)
+    hash_received = ""
+    data = []
+    for k, v in pairs:
+        if k == "hash":
+            hash_received = v
+        else:
+            data.append(f"{k}={v}")
     if not hash_received:
         return False
-    data_check = "\n".join(
-        f"{k}={v}" for k, v in sorted(parsed) if k != "hash"
-    )
+    data.sort()
+    data_check_string = "\n".join(data)
     secret_key = hashlib.sha256(token.encode()).digest()
-    h = hmac.new(secret_key, data_check.encode(), hashlib.sha256).hexdigest()
-    return h == hash_received
+    calculated = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(calculated, hash_received)
+
+
+def require_auth(authorization: str = Header(..., alias="Authorization")):
+    if not validate_telegram_init_data(authorization):
+        raise HTTPException(401, "Unauthorized")
 

--- a/table_manager.py
+++ b/table_manager.py
@@ -25,7 +25,7 @@ class TableManager:
         tables.leave_table(table_id, player_id)
 
         # 3) Broadcast через WS
-        await game_ws.broadcast_state(table_id)
+        await game_ws.broadcast(table_id)
         return {"status": "ok"}
 
     @staticmethod
@@ -46,7 +46,13 @@ class TableManager:
         tables.join_table(player_id, table_id, deposit, seat_idx)
         # 2) Обновляем состояние в game_states
         state = game_engine.game_states.setdefault(
-            table_id, game_engine.create_new_state(cfg["max_players"])
+            table_id,
+            {
+                "seats": [None] * cfg.get("max_players", 6),
+                "player_seats": {},
+                "players": [],
+                "stacks": {},
+            },
         )
         # Проверяем, что место свободно
         if state["seats"][seat_idx] is not None:
@@ -57,5 +63,5 @@ class TableManager:
         # Инициализируем стек
         state["stacks"][player_id] = deposit
         # 3) Рассылаем обновлённый стейт
-        await game_ws.broadcast_state(table_id)
+        await game_ws.broadcast(table_id)
         return {"status": "ok"}

--- a/tables.py
+++ b/tables.py
@@ -2,69 +2,116 @@ from fastapi import HTTPException
 
 from game_data import seat_map
 from game_engine import game_states
+from db_utils import set_balance_db
 
-# Глобальный словарь с настройками блайндов по уровням
-BLINDS = {
-    1: (1, 2, 100),
-    2: (2, 4, 200),
-    3: (5, 10, 500),
+# Конфигурация уровней столов
+TABLE_LEVELS = {
+    "low":  {"sb": 0.02, "bb": 0.05, "min_deposit": 2.5, "max_deposit": 25},
+    "mid":  {"sb": 0.25, "bb": 0.50, "min_deposit": 12.5, "max_deposit": 125},
+    "vip":  {"sb": 2.00, "bb": 5.00, "min_deposit": 250, "max_deposit": 1250},
+}
+
+# Перечень созданных столов: id -> {level:str}
+TABLES = {
+    1: {"level": "low"},
+    2: {"level": "mid"},
+    3: {"level": "vip"},
 }
 
 # Минимальное число игроков для старта
 MIN_PLAYERS = 2
 
 # Инициализируем состояния для предустановленных столов
-for tid in BLINDS.keys():
+for tid in TABLES.keys():
     game_states.setdefault(tid, {})
+    seat_map.setdefault(tid, [])
 
 
 def list_tables() -> list:
-    """
-    Возвращает список всех столов с параметрами и числом игроков.
-    """
+    """Возвращает список всех столов с их параметрами."""
     out = []
-    for tid, (sb, bb, bi) in BLINDS.items():
-        users = seat_map.get(tid, [])
+    for tid, meta in TABLES.items():
+        level = meta["level"]
+        cfg = TABLE_LEVELS[level]
         out.append({
             "id": tid,
-            "small_blind": sb,
-            "big_blind": bb,
-            "buy_in": bi,
-            "players": len(users)
+            "level": level,
+            "sb": cfg["sb"],
+            "bb": cfg["bb"],
+            "min_deposit": cfg["min_deposit"],
+            "max_deposit": cfg["max_deposit"],
+            "players": len(seat_map.get(tid, [])),
         })
     return out
 
 
-def create_table(level: int) -> dict:
-    """
-    Создает новый стол по заданному уровню. Возвращает его параметры.
-    """
-    if level not in BLINDS:
+def create_table(level: str) -> dict:
+    """Создает новый стол указанного уровня."""
+    if level not in TABLE_LEVELS:
         raise HTTPException(status_code=400, detail="Invalid level")
-    new_id = max(BLINDS.keys(), default=0) + 1
-    sb, bb, bi = BLINDS[level]
-    BLINDS[new_id] = (sb, bb, bi)
+    new_id = max(TABLES.keys(), default=0) + 1
+    TABLES[new_id] = {"level": level}
     seat_map[new_id] = []
     game_states[new_id] = {}
+    cfg = TABLE_LEVELS[level]
     return {
         "id": new_id,
-        "small_blind": sb,
-        "big_blind": bb,
-        "buy_in": bi,
-        "players": 0
+        "level": level,
+        "sb": cfg["sb"],
+        "bb": cfg["bb"],
+        "min_deposit": cfg["min_deposit"],
+        "max_deposit": cfg["max_deposit"],
+        "players": 0,
     }
 
 
-def join_table(table_id: int, user_id: str) -> dict:
-    """
-    Добавляет пользователя за стол или обновляет его присутствие.
-    Возвращает статус и список игроков.
-    """
+def get_table_config(table_id: int) -> dict:
+    """Возвращает конфигурацию стола."""
+    meta = TABLES.get(table_id)
+    if not meta:
+        raise HTTPException(404, "Table not found")
+    cfg = TABLE_LEVELS[meta["level"]].copy()
+    cfg["level"] = meta["level"]
+    cfg["max_players"] = 6
+    return cfg
+
+
+def join_table(user_id: str, table_id: int, deposit: float, seat_idx: int) -> dict:
+    """Регистрация игрока за столом с указанием депозита и места."""
+    cfg = get_table_config(table_id)
+    if deposit < cfg["min_deposit"] or deposit > cfg["max_deposit"]:
+        raise HTTPException(400, "Deposit out of range")
+
     users = seat_map.setdefault(table_id, [])
-    # Если пользователь уже за столом, удаляем старую запись для переподключения
     if user_id in users:
         users.remove(user_id)
     users.append(user_id)
+
+    # Сохраняем депозит как баланс игрока
+    set_balance_db(user_id, deposit)
+
+    state = game_states.setdefault(
+        table_id,
+        {
+            "seats": [None] * cfg.get("max_players", 6),
+            "player_seats": {},
+            "players": [],
+            "stacks": {},
+            "usernames": {},
+        },
+    )
+
+    if not (0 <= seat_idx < cfg.get("max_players", 6)):
+        raise HTTPException(400, "Invalid seat")
+    if state["seats"][seat_idx] is not None:
+        raise HTTPException(400, "Seat already taken")
+
+    state["seats"][seat_idx] = user_id
+    state["player_seats"][user_id] = seat_idx
+    state["stacks"][user_id] = deposit
+    if user_id not in state["players"]:
+        state["players"].append(user_id)
+
     return {"status": "ok", "players": users}
 
 
@@ -88,3 +135,8 @@ def get_balance(table_id: int, user_id: str) -> dict:
     """
     stacks = game_states.get(table_id, {}).get("stacks", {})
     return {"balance": stacks.get(user_id, 0)}
+
+
+def get_players(table_id: int) -> list:
+    """Список id игроков за столом."""
+    return seat_map.get(table_id, [])

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -149,12 +149,28 @@ export function renderTable(tableState, userId) {
 
 // Сажаем игрока на место (используем глобальные window.currentTableId/ currentUserId)
 function joinSeat(seatId) {
+  const min = window.tableMin;
+  const max = window.tableMax;
+  const dep = parseFloat(prompt(`Ваш депозит [${min}\u2013${max}]`));
+  if (!dep || dep < min || dep > max) {
+    alert('Неверный депозит');
+    return;
+  }
   fetch(
-    `/api/join-seat?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}`,
-    { method: 'POST' }
-  ).then(() => {
-    reloadGameState();
-  });
+    `/api/join?table_id=${window.currentTableId}&user_id=${window.currentUserId}&seat=${seatId}&deposit=${dep}`,
+    { method: 'POST', headers: { Authorization: window.initData } }
+  )
+    .then(res => {
+      if (res.ok) {
+        connectWs(seatId);
+      } else {
+        res.text().then(t => alert(t));
+      }
+    })
+    .catch(err => {
+      alert('Ошибка подключения');
+      console.error(err);
+    });
 }
 
 // На resize — перерисовка

--- a/webapp/js/ws.js
+++ b/webapp/js/ws.js
@@ -8,11 +8,12 @@ import { getGameState } from './api.js';
  * @param {function(MessageEvent):void} onMessage
  * @returns {WebSocket}
  */
-export function createWebSocket(tableId, userId, username, onMessage) {
+export function createWebSocket(tableId, userId, seat, onMessage) {
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  const url = `${protocol}://${window.location.host}/ws/game/${tableId}` +
-              `?user_id=${encodeURIComponent(userId)}` +
-              `&username=${encodeURIComponent(username)}`;
+  const url =
+    `${protocol}://${window.location.host}` +
+    `/ws/game/${tableId}/${encodeURIComponent(userId)}/${seat}` +
+    `?initData=${encodeURIComponent(window.initData)}`;
 
   const ws = new WebSocket(url);
 


### PR DESCRIPTION
## Summary
- rework table configuration with three levels and deposit ranges
- enforce Telegram WebApp auth via headers
- update table manager and WebSocket endpoints for seat/deposit
- overhaul lobby and game UI scripts to use auth headers and deposits

## Testing
- `python -m py_compile auth.py game_ws.py server.py table_manager.py tables.py`

------
https://chatgpt.com/codex/tasks/task_e_687bc79dac34832c8cd4a20ce82c551f