### PR TITLE
Fix optional auth & propagate initData

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,4 +1,5 @@
 import os, hashlib, hmac, urllib.parse
+from typing import Optional
 from fastapi import Header, HTTPException
 
 
@@ -24,7 +25,8 @@ def validate_telegram_init_data(init_data: str) -> bool:
     return hmac.compare_digest(calculated, hash_received)
 
 
-def require_auth(authorization: str = Header(..., alias="Authorization")):
-    if not validate_telegram_init_data(authorization):
+def require_auth(authorization: Optional[str] = Header(None, alias="Authorization")):
+    # если заголовок пришёл — проверяем подпись, иначе пропускаем
+    if authorization is not None and not validate_telegram_init_data(authorization):
         raise HTTPException(401, "Unauthorized")
 

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import os
 import uvicorn
-from fastapi import FastAPI, Query, Depends, Header, HTTPException
+from fastapi import FastAPI, Query, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
@@ -45,7 +45,7 @@ app.include_router(game_router)
 
 # API для игровых столов
 @app.get("/api/tables")
-def get_tables(level: str = Query(...), auth=Depends(require_auth)):
+def get_tables(level: str = Query(...)):
     """Получить список столов указанного уровня"""
     all_tables = list_tables()
     return {"tables": [t for t in all_tables if t["level"] == level]}
@@ -88,7 +88,7 @@ async def leave_table_endpoint(
     return result
 
 @app.get("/api/balance")
-async def api_get_balance(user_id: str = Query(...), auth=Depends(require_auth)):
+async def api_get_balance(user_id: str = Query(...)):
     """Возвращает текущий баланс игрока из БД."""
     bal = get_balance_db(user_id)
     return {"balance": bal}

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -2,35 +2,58 @@
 const BASE = '';
 
 export async function listTables(level) {
-  const res = await fetch(`${BASE}/api/tables?level=${encodeURIComponent(level)}`);
+  const url = `${BASE}/api/tables?level=${encodeURIComponent(level)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
+  });
   if (!res.ok) throw new Error(`listTables error ${res.status}`);
   return await res.json();
 }
 
 export async function createTable(level) {
-  const res = await fetch(`${BASE}/api/tables?level=${encodeURIComponent(level)}`, {
+  const url = `${BASE}/api/tables?level=${encodeURIComponent(level)}`;
+  const res = await fetch(url, {
     method: 'POST',
+    headers: {
+      Authorization: window.initData,
+    },
   });
   if (!res.ok) throw new Error(`createTable error ${res.status}`);
   return await res.json();
 }
 
 export async function joinTable(tableId, userId) {
-  const res = await fetch(`${BASE}/api/join?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`, {
+  const url = `${BASE}/api/join?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`;
+  const res = await fetch(url, {
     method: 'POST',
+    headers: {
+      Authorization: window.initData,
+    },
   });
   if (!res.ok) throw new Error(`joinTable error ${res.status}`);
   return await res.json();
 }
 
 export async function getBalance(tableId, userId) {
-  const res = await fetch(`${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`);
+  const url = `${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
+  });
   if (!res.ok) throw new Error(`getBalance error ${res.status}`);
   return await res.json();
 }
 
 export async function getGameState(tableId) {
-  const res = await fetch(`${BASE}/api/game_state?table_id=${tableId}`);
+  const url = `${BASE}/api/game_state?table_id=${tableId}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: window.initData,
+    }
+  });
   if (!res.ok) throw new Error(`getGameState error ${res.status}`);
   return await res.json();
 }


### PR DESCRIPTION
## Summary
- allow missing Authorization header in `require_auth`
- make `/api/tables` and `/api/balance` public
- include auth header on every API request from `webapp/js/api.js`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bcac166b8832cbaae3700bb504185