### PR TITLE
Fix API auth and improve lobby initialization

### DIFF
--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -36,8 +36,8 @@ export async function joinTable(tableId, userId) {
   return await res.json();
 }
 
-export async function getBalance(tableId, userId) {
-  const url = `${BASE}/api/balance?table_id=${tableId}&user_id=${encodeURIComponent(userId)}`;
+export async function getBalance(userId) {
+  const url = `${BASE}/api/balance?user_id=${encodeURIComponent(userId)}`;
   const res = await fetch(url, {
     headers: {
       Authorization: window.initData,

--- a/webapp/js/ui_game.js
+++ b/webapp/js/ui_game.js
@@ -1,10 +1,9 @@
 import { createWebSocket } from './ws.js';
 import { renderTable } from './table_render.js';
+import { initTelegramData } from './user.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  window.initData = window.Telegram?.WebApp?.initData || '';
-  Telegram.WebApp?.ready();
-});
+// Инициализируем initData сразу
+initTelegramData();
 
 console.log('[ui_game] loaded, params:', {
   tableId: new URLSearchParams(window.location.search).get('table_id'),

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -1,106 +1,75 @@
 // Этот модуль использует только fetch
+import { initTelegramData, getUserInfo } from './user.js';
 
+// Инициализируем initData сразу, чтобы все запросы содержали подпись
+initTelegramData();
+
+// Основной блок инициализации выполняем после полной загрузки DOM
 document.addEventListener('DOMContentLoaded', () => {
-  window.initData = window.Telegram?.WebApp?.initData || '';
-  Telegram.WebApp?.ready();
-});
+  const infoContainer = document.getElementById('info');
+  const levelSelect   = document.getElementById('level-select');
+  const usernameEl    = document.getElementById('username');
+  const balanceSpan   = document.getElementById('current-balance');
 
-const infoContainer = document.getElementById('info');
-const levelSelect   = document.getElementById('level-select');
-const usernameEl    = document.getElementById('username');
-const balanceSpan   = document.getElementById('current-balance'); // Для баланса
+  const { userId, username } = getUserInfo();
+  usernameEl.textContent = username;
 
-// Генератор «авто-ID» на случай, если не залогинились через Telegram
-function generateId() {
-  return 'user_' + [...crypto.getRandomValues(new Uint8Array(4))]
-    .map(b => b.toString(16).padStart(2, '0')).join('');
-}
-
-// Получаем user_id и username из URL, localStorage или генерим новые
-function getUserInfo() {
-  const params = new URLSearchParams(window.location.search);
-  let uid = params.get('user_id') || localStorage.getItem('user_id');
-  let uname = params.get('username') || localStorage.getItem('username');
-
-  // Сохраняем в localStorage, если пришло из URL
-  if (params.get('user_id')) {
-    localStorage.setItem('user_id', uid);
-  }
-  if (params.get('username')) {
-    localStorage.setItem('username', uname);
-  }
-
-  // Генерируем ID, если нет
-  if (!uid) {
-    uid = generateId();
-    localStorage.setItem('user_id', uid);
-  }
-  // Дефолт для username — это uid
-  if (!uname) {
-    uname = uid;
-    localStorage.setItem('username', uname);
-  }
-
-  // Отображаем в UI
-  usernameEl.textContent = uname;
-
-  return { uid, uname };
-}
-
-const { uid: userId, uname: username } = getUserInfo();
-
-// ======= Баланс =======
-if (balanceSpan) {
-  fetch(`/api/balance?user_id=${userId}`)
-    .then(res => res.json())
-    .then(data => {
-      balanceSpan.innerText = `${data.balance} USDT`;
-    })
-    .catch(() => {
-      balanceSpan.innerText = 'Ошибка';
-    });
-}
-
-// Загрузка списка столов
-async function loadTables() {
-  infoContainer.textContent = 'Загрузка…';
-  try {
-    const res = await fetch(`/api/tables?level=${levelSelect.value}`, {
+  // ======= Баланс =======
+  if (balanceSpan) {
+    fetch(`/api/balance?user_id=${encodeURIComponent(userId)}`, {
       headers: { Authorization: window.initData },
-    });
-    if (!res.ok) throw new Error('fetch tables');
-    const { tables } = await res.json();
-    infoContainer.innerHTML = '';
-    if (!tables.length) {
-      infoContainer.textContent = 'Нет доступных столов';
-      return;
-    }
-    tables.forEach(t => {
-      const card = document.createElement('div');
-      card.className = 'table-card';
-      card.innerHTML = `
-        <h3>Стол ${t.id}</h3>
-        <p>SB/BB: ${t.sb}/${t.bb}</p>
-        <p>Депозит: [${t.min_deposit} – ${t.max_deposit}] | Игроки: ${t.players}</p>
-        <button class="join-btn">Играть</button>
-      `;
-      card.querySelector('.join-btn').addEventListener('click', () => {
-        const uidParam = encodeURIComponent(userId);
-        const unameParam = encodeURIComponent(username);
-        window.open(
-          `/game.html?table_id=${t.id}&user_id=${uidParam}&username=${unameParam}` +
-          `&min=${t.min_deposit}&max=${t.max_deposit}`,
-          '_blank'
-        );
+    })
+      .then(res => res.json())
+      .then(data => {
+        balanceSpan.innerText = `${data.balance} USDT`;
+      })
+      .catch(err => {
+        console.error(err);
+        balanceSpan.innerText = 'Ошибка';
       });
-      infoContainer.appendChild(card);
-    });
-  } catch (err) {
-    alert('Ошибка загрузки столов');
-    console.error(err);
-    infoContainer.textContent = 'Ошибка загрузки столов!';
   }
-}
 
-levelSelect.addEventListener('change', loadTables);
-loadTables();
+  async function loadTables() {
+    infoContainer.textContent = 'Загрузка…';
+    try {
+      const res = await fetch(
+        `/api/tables?level=${encodeURIComponent(levelSelect.value)}`,
+        { headers: { Authorization: window.initData } }
+      );
+      if (!res.ok) throw new Error('fetch tables');
+      const { tables } = await res.json();
+      infoContainer.innerHTML = '';
+      if (!tables || !tables.length) {
+        infoContainer.textContent = 'Нет доступных столов';
+        return;
+      }
+      tables.forEach(t => {
+        const card = document.createElement('div');
+        card.className = 'table-card';
+        card.innerHTML = `
+          <h3>Стол ${t.id}</h3>
+          <p>SB/BB: ${t.sb}/${t.bb}</p>
+          <p>Депозит: [${t.min_deposit} – ${t.max_deposit}] | Игроки: ${t.players}</p>
+          <button class="join-btn">Играть</button>
+        `;
+        card.querySelector('.join-btn').addEventListener('click', () => {
+          const uidParam = encodeURIComponent(userId);
+          const unameParam = encodeURIComponent(username);
+          window.open(
+            `/game.html?table_id=${t.id}&user_id=${uidParam}&username=${unameParam}` +
+              `&min=${t.min_deposit}&max=${t.max_deposit}`,
+            '_blank'
+          );
+        });
+        infoContainer.appendChild(card);
+      });
+    } catch (err) {
+      console.error(err);
+      alert('Ошибка загрузки столов');
+      infoContainer.textContent = 'Ошибка загрузки столов!';
+    }
+  }
+
+  levelSelect.addEventListener('change', loadTables);
+  loadTables();
+});


### PR DESCRIPTION
## Summary
- require Telegram authorization for `/api/tables` and `/api/balance`
- initialize Telegram initData before any requests
- wrap lobby code inside `DOMContentLoaded`
- reuse user helper methods
- update API helper for balance endpoint

## Testing
- `python -m py_compile server.py auth.py tables.py table_manager.py db_utils.py game_ws.py game_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_687bcc1b5e18832c8d1e9db85b482426