### PR TITLE
Add multi-level tables and optional Telegram auth

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -21,7 +21,9 @@ def validate_telegram_init_data(init_data: str) -> bool:
     data.sort()
     data_check_string = "\n".join(data)
     secret_key = hashlib.sha256(token.encode()).digest()
-    calculated = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    calculated = hmac.new(
+        secret_key, data_check_string.encode(), hashlib.sha256
+    ).hexdigest()
     return hmac.compare_digest(calculated, hash_received)
 
 
@@ -29,4 +31,3 @@ def require_auth(authorization: Optional[str] = Header(None, alias="Authorizatio
     # если заголовок пришёл — проверяем подпись, иначе пропускаем
     if authorization is not None and not validate_telegram_init_data(authorization):
         raise HTTPException(401, "Unauthorized")
-

--- a/tables.py
+++ b/tables.py
@@ -6,9 +6,9 @@ from db_utils import set_balance_db
 
 # Конфигурация уровней столов
 TABLE_LEVELS = {
-    "low":  {"sb": 0.02, "bb": 0.05, "min_deposit": 2.5, "max_deposit": 25},
-    "mid":  {"sb": 0.25, "bb": 0.50, "min_deposit": 12.5, "max_deposit": 125},
-    "vip":  {"sb": 2.00, "bb": 5.00, "min_deposit": 250, "max_deposit": 1250},
+    "low": {"sb": 0.02, "bb": 0.05, "min_deposit": 2.5, "max_deposit": 25},
+    "mid": {"sb": 0.25, "bb": 0.50, "min_deposit": 12.5, "max_deposit": 125},
+    "vip": {"sb": 2.00, "bb": 5.00, "min_deposit": 250, "max_deposit": 1250},
 }
 
 # Перечень созданных столов: id -> {level:str}
@@ -33,15 +33,17 @@ def list_tables() -> list:
     for tid, meta in TABLES.items():
         level = meta["level"]
         cfg = TABLE_LEVELS[level]
-        out.append({
-            "id": tid,
-            "level": level,
-            "sb": cfg["sb"],
-            "bb": cfg["bb"],
-            "min_deposit": cfg["min_deposit"],
-            "max_deposit": cfg["max_deposit"],
-            "players": len(seat_map.get(tid, [])),
-        })
+        out.append(
+            {
+                "id": tid,
+                "level": level,
+                "sb": cfg["sb"],
+                "bb": cfg["bb"],
+                "min_deposit": cfg["min_deposit"],
+                "max_deposit": cfg["max_deposit"],
+                "players": len(seat_map.get(tid, [])),
+            }
+        )
     return out
 
 

--- a/webapp/js/table_render.js
+++ b/webapp/js/table_render.js
@@ -1,5 +1,10 @@
 const N_SEATS = 6;
 
+let customJoinHandler = null;
+export function setJoinHandler(fn) {
+  customJoinHandler = fn;
+}
+
 // Углы для 6 мест (seat 0 внизу по центру)
 function getSeatAngles(N) {
   if (N === 6) return [90, 150, 210, 270, 330, 30];
@@ -149,6 +154,10 @@ export function renderTable(tableState, userId) {
 
 // Сажаем игрока на место (используем глобальные window.currentTableId/ currentUserId)
 function joinSeat(seatId) {
+  if (typeof customJoinHandler === 'function') {
+    customJoinHandler(seatId);
+    return;
+  }
   const min = window.tableMin;
   const max = window.tableMax;
   const dep = parseFloat(prompt(`Ваш депозит [${min}\u2013${max}]`));

--- a/webapp/js/ui_lobby.js
+++ b/webapp/js/ui_lobby.js
@@ -1,11 +1,12 @@
 // Этот модуль использует только fetch
-import { initTelegramData, getUserInfo } from './user.js';
-
-// Инициализируем initData сразу, чтобы все запросы содержали подпись
-initTelegramData();
+import { getUserInfo } from './user.js';
 
 // Основной блок инициализации выполняем после полной загрузки DOM
 document.addEventListener('DOMContentLoaded', () => {
+  window.initData = window.Telegram?.WebApp?.initData || '';
+  if (window.Telegram?.WebApp?.ready) {
+    window.Telegram.WebApp.ready();
+  }
   const infoContainer = document.getElementById('info');
   const levelSelect   = document.getElementById('level-select');
   const usernameEl    = document.getElementById('username');

--- a/webapp/js/ws.js
+++ b/webapp/js/ws.js
@@ -1,5 +1,12 @@
 import { getGameState } from './api.js';
 
+document.addEventListener('DOMContentLoaded', () => {
+  window.initData = window.Telegram?.WebApp?.initData || '';
+  if (window.Telegram?.WebApp?.ready) {
+    window.Telegram.WebApp.ready();
+  }
+});
+
 /**
  * Создаёт и настраивает WebSocket для игры
  * @param {string} tableId


### PR DESCRIPTION
## Summary
- implement Telegram auth helper and optional header logic
- update server endpoints to depend on `require_auth`
- support table levels and joining logic
- move join handling to `ui_game` and expose hook in `table_render`
- initialize Telegram `initData` on DOMContentLoaded for lobby, game and ws modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bceb46654832cb741b2b62457484c